### PR TITLE
Restore default SPI path to keep tests and utils working.

### DIFF
--- a/libloragw/src/loragw_spi.native.c
+++ b/libloragw/src/loragw_spi.native.c
@@ -54,7 +54,8 @@ Maintainer: Sylvain Miermont
 #define READ_ACCESS     0x00
 #define WRITE_ACCESS    0x80
 #define SPI_SPEED       8000000
-char spi_dev_path[50];
+// default SPI path
+char spi_dev_path[50] = "/dev/spidev0.0";
 
 /* -------------------------------------------------------------------------- */
 /* --- PUBLIC FUNCTIONS DEFINITION ------------------------------------------ */


### PR DESCRIPTION
Removing the default SPI path makes the test/util binaries unusable. This patch fixes that by setting back the default SPI path to /dev/spidev0.0 while it's compatible with the lgw_spi_set_path function.

A better approach would be to update the test and util binaries to accept the path through opt args and use also lgw_spi_set_path but this is not worth the effort and SPI bus 0 is quite common.